### PR TITLE
Add guidance around on-topic questions for Stack Overflow

### DIFF
--- a/articles/resources-links-help.md
+++ b/articles/resources-links-help.md
@@ -19,7 +19,7 @@ These resources provide additional information and support for developing bots w
 
 |**Support type**                    | **Contact**                                                
 |----------------------------|---------------------------------
-|**Community support** | [StackOverflow](https://stackoverflow.com/questions/tagged/botframework)
+|**Community support** | Questions can be posted at [Stack Overflow](https://stackoverflow.com/questions/tagged/botframework). Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.
 |**Community chat group** | [Gitter.IM](https://gitter.im/Microsoft/BotBuilder)
 |**Using a bot** | Contact the bot's developer through their publisher e-mail                 
 |**Bot Builder SDK issues/suggestions**| Use the issues tab on the <a href="https://github.com/Microsoft/BotBuilder/" target="_blank">GitHub repo</a>

--- a/articles/resources-links-help.md
+++ b/articles/resources-links-help.md
@@ -6,7 +6,7 @@ ms.author: rstand
 manager: rstand
 ms.topic: article
 ms.prod: bot-framework
-ms.date: 08/07/2017
+ms.date: 10/10/2017
 ---
 
 # Bot Framework additional resources
@@ -19,7 +19,7 @@ These resources provide additional information and support for developing bots w
 
 |**Support type**                    | **Contact**                                                
 |----------------------------|---------------------------------
-|**Community support** | Questions can be posted at [Stack Overflow](https://stackoverflow.com/questions/tagged/botframework). Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.
+|**Community support** | Questions can be posted at [Stack Overflow](https://stackoverflow.com/questions/tagged/botframework) using the `botframework` tag. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.
 |**Community chat group** | [Gitter.IM](https://gitter.im/Microsoft/BotBuilder)
 |**Using a bot** | Contact the bot's developer through their publisher e-mail                 
 |**Bot Builder SDK issues/suggestions**| Use the issues tab on the <a href="https://github.com/Microsoft/BotBuilder/" target="_blank">GitHub repo</a>

--- a/articles/resources/TOC.md
+++ b/articles/resources/TOC.md
@@ -1,4 +1,3 @@
-# [Support](http://stackoverflow.com/questions/tagged/botframework)
 # [FAQ](../resources-bot-framework-faq.md)
 # [Additional resources](../resources-links-help.md)
 # [Guide to identifiers](../resources-identifiers-guide.md)

--- a/articles/troubleshoot-general-problems.md
+++ b/articles/troubleshoot-general-problems.md
@@ -6,7 +6,7 @@ ms.author: v-demak
 manager: rstand
 ms.topic: article
 ms.prod: bot-framework
-ms.date: 06/02/2017
+ms.date: 10/10/2017
 ---
 
 # Troubleshooting general problems
@@ -243,7 +243,7 @@ Both the Bot Builder SDK for Node.js and the Bot Builder SDK for .NET support ca
 
 ## Where can I get more help?
 
-* Leverage the information in previously answered questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/botframework), or post your own questions using the `botframework` tag.
+* Leverage the information in previously answered questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/botframework), or post your own questions using the `botframework` tag. Please note that Stack Overflow has guidelines such as requiring a descriptive title, a complete and concise problem statement, and sufficient details to reproduce your issue. Feature requests or overly broad questions are off-topic; new users should visit the [Stack Overflow Help Center](https://stackoverflow.com/help/how-to-ask) for more details.
 * Consult [BotBuilder issues](https://github.com/Microsoft/BotBuilder/issues) in GitHub for information about known issues with the Bot Builder SDK, or to report a new issue.
 * Leverage the information in the BotBuilder community discussion on [Gitter](https://gitter.im/Microsoft/BotBuilder).
 

--- a/contributor-guide/tools-and-setup.md
+++ b/contributor-guide/tools-and-setup.md
@@ -2,7 +2,7 @@
 
 Follow the steps in this article to set up tools for contributing to the Bot Framework technical documentation. Casual and occasional contributors probably can use the GitHub UI described in step 2.
 
-If you're unfamiliar with Git, you might want to review some Git terminology: [https://help.github.com/articles/github-glossary](https://help.github.com/articles/github-glossary). In addition, this StackOverflow thread contains a glossary of Git terms you'll encounter here: [http://stackoverflow.com/questions/7076164/terminology-used-by-git](http://stackoverflow.com/questions/7076164/terminology-used-by-git)
+If you're unfamiliar with Git, you might want to review some Git terminology: [https://help.github.com/articles/github-glossary](https://help.github.com/articles/github-glossary). In addition, this StackOverflow post contains a glossary of Git terms you'll encounter here: [http://stackoverflow.com/questions/7076164/terminology-used-by-git](http://stackoverflow.com/questions/7076164/terminology-used-by-git)
 
 ## Contents
 * [Create a GitHub account and set up your profile](#create-a-github-account-and-set-up-your-profile)

--- a/contributor-guide/tools-and-setup.md
+++ b/contributor-guide/tools-and-setup.md
@@ -2,7 +2,7 @@
 
 Follow the steps in this article to set up tools for contributing to the Bot Framework technical documentation. Casual and occasional contributors probably can use the GitHub UI described in step 2.
 
-If you're unfamiliar with Git, you might want to review some Git terminology: [https://help.github.com/articles/github-glossary](https://help.github.com/articles/github-glossary). In addition, this StackOverflow post contains a glossary of Git terms you'll encounter here: [http://stackoverflow.com/questions/7076164/terminology-used-by-git](http://stackoverflow.com/questions/7076164/terminology-used-by-git)
+If you're unfamiliar with Git, you might want to review some Git terminology: [https://help.github.com/articles/github-glossary](https://help.github.com/articles/github-glossary). In addition, this Stack Overflow post contains a glossary of Git terms you'll encounter here: [http://stackoverflow.com/questions/7076164/terminology-used-by-git](http://stackoverflow.com/questions/7076164/terminology-used-by-git)
 
 ## Contents
 * [Create a GitHub account and set up your profile](#create-a-github-account-and-set-up-your-profile)


### PR DESCRIPTION
This PR tweaks wording and adds guidance around the types of questions which are and are not appropriate to post on Stack Overflow. By directing users to the "How To Ask" guide before sending them to Stack Overflow, the likelihood of posting a well received, answerable question should be markedly improved.

Context for this change is described in #61.