### PR TITLE
Removing "confirmPrompt" on reload action

### DIFF
--- a/articles/nodejs/bot-builder-nodejs-dialog-replace.md
+++ b/articles/nodejs/bot-builder-nodejs-dialog-replace.md
@@ -211,8 +211,7 @@ bot.dialog("addDinnerItem", [
 .reloadAction(
     "restartOrderDinner", "Ok. Let's start over.",
     {
-        matches: /^start over$/i,
-        confirmPrompt: "This will cancel your order. Are you sure?"
+        matches: /^start over$/i
     }
 );
 ```

--- a/articles/nodejs/bot-builder-nodejs-dialog-replace.md
+++ b/articles/nodejs/bot-builder-nodejs-dialog-replace.md
@@ -135,8 +135,7 @@ bot.dialog('orderDinner', [
 .reloadAction(
     "restartOrderDinner", "Ok. Let's start over.",
     {
-        matches: /^start over$/i,
-        confirmPrompt: "This wil cancel your order. Are you sure?"
+        matches: /^start over$/i
     }
 )
 .cancelAction(


### PR DESCRIPTION
As documentation is saying here: https://docs.botframework.com/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialog.html#reloadaction , reload action doesn't handle "confirmPrompt" (more details available on IBeginDialogActionOptions documentation about what is really available for reloadAction)