### PR TITLE
content vs. contentUrl for attachment in base64

### DIFF
--- a/articles/rest-api/bot-framework-rest-connector-add-media-attachments.md
+++ b/articles/rest-api/bot-framework-rest-connector-add-media-attachments.md
@@ -60,7 +60,34 @@ Content-Type: application/json
 }
 ```
 
-For channels that support inline binaries of an image, you can set the `content` property of the `Attachment` to a base64 binary of the image (for example, **data:image/png;base64,iVBORw0KGgo…**). The channel will display the image or the image's URL next to the message's text string.
+For channels that support inline binaries of an image, you can set the `contentUrl` property of the `Attachment` to a base64 binary of the image (for example, **data:image/png;base64,iVBORw0KGgo…**). The channel will display the image or the image's URL next to the message's text string.
+
+```json
+{
+    "type": "message",
+    "from": {
+        "id": "12345678",
+        "name": "sender's name"
+    },
+    "conversation": {
+        "id": "abcd1234",
+        "name": "conversation's name"
+   },
+   "recipient": {
+        "id": "1234abcd",
+        "name": "recipient's name"
+    },
+    "text": "Here's a picture of the duck I was telling you about.",
+    "attachments": [
+        {
+            "contentType": "image/png",
+            "contentUrl": "data:image/png;base64,iVBORw0KGgo…",
+            "name": "duck-on-a-rock.jpg"
+        }
+    ],
+    "replyToId": "5d5cdc723"
+}
+```
 
 You can attach a video file or audio file to a message by using the same process as described above for an image file. Depending on the channel, the video and audio may be played inline or it may be displayed as a link.
 


### PR DESCRIPTION
Here is my testing python3 code:

```python
    skype_bot_data = {
        "type": "message",
        "text": "Hello",
        "from": {
            "id": "real-python-user",
            "name": "Real Python User"
        },
        "channelId": "skype",
        "conversation": {
            "id": CONVERSATION_ID
            # "name": "",
            # "isGroup": True
        },
        # "recipient": {
        #     "id": "1234abcd",
        #     "name": "recipient's name"
        # },
        "attachments": [
            {
                # "contentType": "image/png",
                "contentType": "image/jpeg",
                # If omit contentType, then Skype API shows error; "ContentType of an attachment is not set" on SKype Bot manage page
                
                # "content": "data:image/png;base64,"+recognised_file_base64_string,
                # "content": "data:image/jpeg;base64,"+recognised_file_base64_string,
                # if use "content" => error about contentUrl
                
                "contentUrl": "data:image/png;base64,"+recognised_file_base64_string,
                # "contentUrl": "https://www.planwallpaper.com/static/images/9-credit-1.jpg", #works
                "name": "file-name.jpg"
            }
        ]
        # "replyToId": "5d5cdc723"
    }
```

Btw, looks like it doesn't matter if contentType is proper, but it always must be set with base64 `contentUrl`