### PR TITLE
Fix syntax error

### DIFF
--- a/articles/nodejs/bot-builder-nodejs-dialog-actions.md
+++ b/articles/nodejs/bot-builder-nodejs-dialog-actions.md
@@ -257,7 +257,7 @@ bot.dialog('orderDinner', [
 // Confirm before triggering the action.
 // Once triggered, will end the dialog. 
 .cancelAction('cancelAction', 'Ok, cancel order.', {
-    matches: /^nevermind$|^cancel$|^cancel.*order/i
+    matches: /^nevermind$|^cancel$|^cancel.*order/i,
     confirmPrompt: "Are you sure?"
 });
 ```


### PR DESCRIPTION
There should be a comma between two key-value pairs in JSON.