### PR TITLE
Adding bot modification procedure to bot registration

### DIFF
--- a/articles/bot-service-quickstart-registration.md
+++ b/articles/bot-service-quickstart-registration.md
@@ -61,10 +61,14 @@ To generate a MicrosoftAppPassword, do the following:
 ## Update the bot
 
 If you're using the Bot Builder SDK for Node.js, set the following environment variables:
-<ul><li>MICROSOFT_APP_ID</li><li>MICROSOFT_APP_PASSWORD</li></ul>
+
+* MICROSOFT_APP_ID
+* MICROSOFT_APP_PASSWORD
 
 If you're using the Bot Builder SDK for .NET, set the following key values in the web.config file:
-<ul><li>MicrosoftAppId</li><li>MicrosoftAppPassword</li></ul>
+
+* MicrosoftAppId
+* MicrosoftAppPassword
 
 ## Test the bot
 

--- a/articles/bot-service-quickstart-registration.md
+++ b/articles/bot-service-quickstart-registration.md
@@ -58,6 +58,14 @@ To generate a MicrosoftAppPassword, do the following:
 2. Click **Generate New Password**. This will generate a new password for your bot. Copy this password and save it to a file. This is the only time you will see this password. If you do not have the full password saved, you will need to repeat the process to create a new password should you need it later. <br/>
   ![Generate Microsoft App Password](~/media/azure-bot-quickstarts/registration-generate-app-password.png)
 
+## Update the bot
+
+If you're using the Bot Builder SDK for Node.js, set the following environment variables:
+<ul><li>MICROSOFT_APP_ID</li><li>MICROSOFT_APP_PASSWORD</li></ul>
+
+If you're using the Bot Builder SDK for .NET, set the following key values in the web.config file:
+<ul><li>MicrosoftAppId</li><li>MicrosoftAppPassword</li></ul>
+
 ## Test the bot
 
 Now that your bot service is created, [test it in Web Chat](bot-service-manage-test-webchat.md). Enter a message and your bot should respond.


### PR DESCRIPTION
I believe that the application environment strings need to be modified before testing the bot.
These notations are taken from [articles/includes/snippet-tip-bot-config-settings.md](/MicrosoftDocs/bot-framework-docs/blob/live/articles/includes/snippet-tip-bot-config-settings.md) just for example.