### PR TITLE
Update env variable naming to work with post-GA bot service

### DIFF
--- a/articles/includes/code/node-getstarted.js
+++ b/articles/includes/code/node-getstarted.js
@@ -21,8 +21,8 @@ server.listen(process.env.port || process.env.PORT || 3978, function () {
 
 // Create chat connector for communicating with the Bot Framework Service
 var connector = new builder.ChatConnector({
-    appId: process.env.MICROSOFT_APP_ID,
-    appPassword: process.env.MICROSOFT_APP_PASSWORD
+    appId: process.env.MicrosoftAppId,
+    appPassword: process.env.MicrosoftAppPassword
 });
 
 // Listen for messages from users 


### PR DESCRIPTION
Per bug report - fix for https://github.com/Microsoft/BotBuilder/issues/4068