### PR TITLE
in C# can't set score > 1.0

### DIFF
--- a/articles/nodejs/bot-builder-nodejs-recognize-intent-messages.md
+++ b/articles/nodejs/bot-builder-nodejs-recognize-intent-messages.md
@@ -49,6 +49,7 @@ Once you've registered a recognizer, you can associate the recognizer with an ac
 ## Disambiguate between multiple intents
 
 Your bot can register more than one recognizer. Notice that the custom recognizer example involves assigning a numerical score to each intent. This is done since your bot may have more than one recognizer, and the Bot Builder SDK provides built-in logic to disambiguate between intents returned by multiple recognizers. The score assigned to an intent is typically between 0.0 and 1.0, but a custom recognizer may define an intent greater than 1.1 to ensure that that intent will always be chosen by the Bot Builder SDK's disambiguation logic. 
+(However, in the C# Bot Builder SDK you can not return a score greater than 1.0).
 
 By default, recognizers run in parallel, but you can set recognizeOrder in [IIntentRecognizerSetOptions][IntentRecognizerSetOptions] so the process quits as soon as your bot finds one that gives a score of 1.0.
 


### PR DESCRIPTION
in the C# Bot Builder SDK you can not return a score greater than 1.0 or less than 0.0

This code in the C# SDK will throw an exception.
https://github.com/Microsoft/BotBuilder/blob/497252e8d9949be20baa2cebaa6ce56de04461cf/CSharp/Library/Microsoft.Bot.Builder/Scorables/Scorables.cs#L375

I was confused by this statement in the documentation than the score can be greater than 1.0. I don't know if it's really possible in Node.js, but in C# it's not. Add the remark just for those, who like me, read this doc to understand the C# behavior.