### PR TITLE
Fixed wrong link for skype configuration page

### DIFF
--- a/articles/includes/snippet-publish-to-channel.md
+++ b/articles/includes/snippet-publish-to-channel.md
@@ -2,7 +2,7 @@
 Bots are published to Cortana from the [dashboard](https://aka.ms/cortana-publish) and are used to power Cortana skills. Publishing a bot submits it for review. Cortana skills can be deployed for your own use, deployed to a small group, or published to the world.
 
 ### Skype
-Bots are published to Skype from the [configuration page](~/bot-service-channel-connect-skypeForBusiness.md). Publishing a bot submits it for review. Before review, the bot is limited to 100 contacts. Approved bots do not have limited contacts and you may opt to have the bot included in the Skype bot directory.
+Bots are published to Skype from the [configuration page](~/bot-service-channel-connect-skype.md). Publishing a bot submits it for review. Before review, the bot is limited to 100 contacts. Approved bots do not have limited contacts and you may opt to have the bot included in the Skype bot directory.
 
 ### Skype for Business
 Skype for Business bots are registered with a [Skype for Business Online tenant](https://msdn.microsoft.com/en-us/skype/Skype-For-Business-Bot-Framework/docs/overview) by a Tenant Administrator.


### PR DESCRIPTION
Fixed wrong link for skype configuration page in snippet-publish-to-channel.md