### PR TITLE
Changed localhost to endpoint in the MSBot services table

### DIFF
--- a/articles/bot-builder-tools-az-cli.md
+++ b/articles/bot-builder-tools-az-cli.md
@@ -154,7 +154,7 @@ msbot connect service-type
 | Service type | Description |
 | ------ | ----------- |
 | azure  |connect your bot to an Azure Bot Service registration|
-|localhost| connect your bot to a localhost endpoint|
+|endpoint| connect your bot to an endpoint such as localhost|
 |luis     | connect your bot to a LUIS application |
 | qna     |connect your bot to a QnA Knowledgebase|
 |help [cmd]  |display help for [cmd]|


### PR DESCRIPTION
Changed MSBot services table to list endpoint instead of localhost, so that it matches the documentation on the MSBot README, and the actual command line switch used when connecting the service.