### PR TITLE
Updated middleware registration in line with 4.0.1-preview

### DIFF
--- a/articles/v4sdk/bot-builder-howto-qna.md
+++ b/articles/v4sdk/bot-builder-howto-qna.md
@@ -91,15 +91,15 @@ public void ConfigureServices(IServiceCollection services)
         options.CredentialProvider = new ConfigurationCredentialProvider(Configuration);
 
         var endpoint = new QnAMakerEndpoint
-            {
-                knowledgebaseId = "YOUR-KB-ID",
-                // Get the Host from the HTTP request example at https://www.qnamaker.ai
-                // For GA services: https://<Service-Name>.azurewebsites.net/qnamaker
-                // For Preview services: https://westus.api.cognitive.microsoft.com/qnamaker/v2.0
-                Host = "YOUR-HTTP-REQUEST-HOST",
-                EndpointKey = "YOUR-QNA-MAKER-SUBSCRIPTION-KEY"
-            };
-        options.Middleware.Add(new QnAMakerMiddleware(new QnAMakerEndpoint(endpoint)));
+        {
+           KnowledgeBaseId = "YOUR-KB-ID",
+           // Get the Host from the HTTP request example at https://www.qnamaker.ai
+           // For GA services: https://<Service-Name>.azurewebsites.net/qnamaker
+           // For Preview services: https://westus.api.cognitive.microsoft.com/qnamaker/v2.0           
+           Host = "YOUR-HTTP-REQUEST-HOST",
+           EndpointKey = "YOUR-QNA-MAKER-SUBSCRIPTION-KEY"
+        };
+        options.Middleware.Add(new QnAMakerMiddleware(endpoint));
     });
 }
 ```


### PR DESCRIPTION
Sample middleware registration was invalid with 4.0.1-preview. Modified so that sample indicates a single QnaMakerRegistration object and fixed casing on KnowledgeBaseId.