### PR TITLE
Fixed reference links to code

### DIFF
--- a/articles/includes/code/dotnet-input-hints.cs
+++ b/articles/includes/code/dotnet-input-hints.cs
@@ -22,31 +22,31 @@ namespace InputHintsPublic
             if (context.Activity.Type == ActivityTypes.Message)
             {
                 {
-                    // <Accepting>
+                    // <Accepting input>
                     var reply = MessageFactory.Text(
                         "This is the text that will be displayed.",
                         "This is the text that will be spoken.",
                         InputHints.AcceptingInput);
                     await context.SendActivity(reply).ConfigureAwait(false);
-                    // </Accepting>
+                    // </Accepting input>
                 }
                 {
-                    // <Expecting>
+                    // <Expecting input>
                     var reply = MessageFactory.Text(
                         "This is the text that will be displayed.",
                         "This is the text that will be spoken.",
                         InputHints.ExpectingInput);
                     await context.SendActivity(reply).ConfigureAwait(false);
-                    // </Expecting>
+                    // </Expecting input>
                 }
                 {
-                    // <Ignoring>
+                    // <Ignoring input>
                     var reply = MessageFactory.Text(
                         "This is the text that will be displayed.",
                         "This is the text that will be spoken.",
                         InputHints.IgnoringInput);
                     await context.SendActivity(reply).ConfigureAwait(false);
-                    // </Ignoring>
+                    // </Ignoring input>
                 }
             }
         }


### PR DESCRIPTION
Code was not showing on Docs page as reference links where pointing to blocks that did not exist.  Example: [!code-csharpAccepting input] was looking for // <Accepting input> but in the linked code it had // <Accepting>. Update the code block reference names